### PR TITLE
21 generic publish message

### DIFF
--- a/functions/run_manager_between/src/main.py
+++ b/functions/run_manager_between/src/main.py
@@ -58,9 +58,11 @@ async def publish_message_async(session, endpoint, date, cumulate_flag):
     date_str = f'{date:%Y-%m-%d}'
     json_args = {
         "topic_name": "scheduled-weekly-9am",
-        "message": f"`run_manager_between` is publishing message on `cheduled-weekly-9am` with `run_date={date_str}`",
-        "run_date": date_str,
-        "cumulate_results": cumulate_flag
+        "message": f"`run_manager_between` asked to publish on `scheduled-weekly-9am` for `run_date={date_str}`",
+        "attributes": {
+            "run_date": date_str,
+            "cumulate_results": cumulate_flag
+        }
     }
     failed_attempts = []
     for attempt_number in range(MAXIMUM_NUMBER_OF_ATTEMPTS):

--- a/manager/bigquery/queries.py
+++ b/manager/bigquery/queries.py
@@ -10,7 +10,7 @@ def run_query(client: bq.Client, query: str, destination_table_name: str) -> Non
     )
     query_job = client.query(query, job_config=job_config)
     general_summary_job_result = query_job.result()
-    print(f'general_summary_job_result completed?: {bool(general_summary_job_result)}')
+    print(f'{destination_table_name}_query_job_result completed?: {bool(general_summary_job_result)}')
     return
 
 
@@ -35,7 +35,7 @@ def create_player_summary_query(dataset_ids: [str]) -> str:
         f"""WITH all_player_summaries AS (
             {query_for_all_player_summaries}
             )
-            SELECT Name, SUM(Winnings_per_Player) AS Total_Cumulated_Winnings
+            SELECT Name, SUM(Winnings_per_Player) AS Total_Cumulated_Winnings, COUNT(Play_Date) AS Days_Played
             FROM all_player_summaries
             GROUP BY Name
         """


### PR DESCRIPTION
Made cloud func `publish_message` more generic. Now expects request with `topic_name`, `message` and `attributes`.

Closes #21 